### PR TITLE
Add the elapsed time to the "Waiting..." message

### DIFF
--- a/lib/watchbuild/runner.rb
+++ b/lib/watchbuild/runner.rb
@@ -39,7 +39,7 @@ module WatchBuild
             time_elapsed = Time.at(seconds_elapsed).utc.strftime "%H:%M:%S hours"
           end
 
-          Helper.log.info "Waiting since #{time_elapsed} for iTunes Connect to process the build #{build.train_version} (#{build.build_version})... this might take a while..."
+          Helper.log.info "Waiting #{time_elapsed} for iTunes Connect to process the build #{build.train_version} (#{build.build_version})... this might take a while..."
         rescue => ex
           Helper.log.error ex
           Helper.log.info "Something failed... trying again to recover"


### PR DESCRIPTION
This PR adds the elapsed time to the log message:
```
[14:55:05]: Waiting 05:32 minutes for iTunes Connect to process the build 1.2.3 (456)... this might take a while...
[14:55:37]: Waiting 06:04 minutes for iTunes Connect to process the build 1.2.3 (456)... this might take a while...
[14:56:10]: Waiting 06:37 minutes for iTunes Connect to process the build 1.2.3 (456)... this might take a while...
[14:56:44]: Waiting 07:11 minutes for iTunes Connect to process the build 1.2.3 (456)... this might take a while...
[14:57:17]: Waiting 07:44 minutes for iTunes Connect to process the build 1.2.3 (456)... this might take a while...
```

I chose to include the seconds, since `find_build` will be called more than once per minute and otherwise it would print: 
```
[14:55:05]: Waiting 5 minutes for iTunes Connect to process the build 1.2.3 (456)... this might take a while...
[14:55:37]: Waiting 6 minutes for iTunes Connect to process the build 1.2.3 (456)... this might take a while...
[14:56:10]: Waiting 6 minutes for iTunes Connect to process the build 1.2.3 (456)... this might take a while...
[14:56:44]: Waiting 7 minutes for iTunes Connect to process the build 1.2.3 (456)... this might take a while...
[14:57:17]: Waiting 7 minutes for iTunes Connect to process the build 1.2.3 (456)... this might take a while...
```

Which looks kind of strange because of the duplicated lines.
