### PR TITLE
Update yard dependency for CVE-2017-17042, rubocop dependency for CVE2017-8418 .

### DIFF
--- a/lib/watchbuild/version.rb
+++ b/lib/watchbuild/version.rb
@@ -1,4 +1,4 @@
 module WatchBuild
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
   DESCRIPTION = 'Get a notification once your App Store Connect build is finished processing'.freeze
 end

--- a/watchbuild.gemspec
+++ b/watchbuild.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'yard', '~> 0.8.7.4'
+  spec.add_development_dependency 'yard', '>= 0.9.11'
   spec.add_development_dependency 'webmock', '~> 1.19.0'
   spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'rubocop', '~> 0.44.0'
+  spec.add_development_dependency 'rubocop', '>= 0.49.0'
 end


### PR DESCRIPTION
### Motivation
#### `yard`
Update for https://nvd.nist.gov/vuln/detail/CVE-2017-17042.

#### `rubocop`
Update for https://nvd.nist.gov/vuln/detail/CVE-2017-8418.

### Questions
- Do I need to bump the version for dev dependency updates? 🤔 